### PR TITLE
Add theme switcher, action menu, and 10 bundled themes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,22 @@
       "WebFetch(domain:docs.rs)",
       "Bash(git init:*)",
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(cargo check:*)",
+      "Bash(cargo test:*)",
+      "Bash(cargo build:*)",
+      "Bash(cargo run:*)",
+      "Bash(target/release/sc:*)",
+      "Bash(echo:*)",
+      "Bash(env:*)",
+      "Bash(git -C /Users/magnuspladsen/git/sexy-claude-code status)",
+      "Bash(git -C /Users/magnuspladsen/git/sexy-claude-code remote -v)",
+      "Bash(gh auth status:*)",
+      "Bash(git -C /Users/magnuspladsen/git/sexy-claude-code diff --cached --stat)",
+      "Bash(git -C /Users/magnuspladsen/git/sexy-claude-code log --oneline)",
+      "Bash(gh repo create:*)",
+      "Skill(commit-commands:commit-push-pr)",
+      "Bash(git checkout:*)"
     ]
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,8 +65,8 @@ async fn main() -> Result<()> {
         anyhow::bail!("Terminal too small ({}x{}). Need at least 40x10.", cols, rows);
     }
 
-    // PTY gets the inner size (minus our chrome: 2 border rows + 1 status bar)
-    let pty_rows = rows.saturating_sub(3);
+    // PTY gets the inner size (minus our chrome: header + 2 border rows + 1 status bar)
+    let pty_rows = rows.saturating_sub(3 + ui::header::HEADER_HEIGHT);
     let pty_cols = cols.saturating_sub(2); // minus left/right borders
 
     // Extra environment for the child process

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -1,0 +1,151 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::Widget;
+
+use crate::theme::Theme;
+
+/// Height of the header area in terminal rows.
+pub const HEADER_HEIGHT: u16 = 3;
+
+/// Animated header widget displaying the sexy-claude brand with a gradient.
+pub struct Header<'a> {
+    theme: &'a Theme,
+    frame_count: u64,
+}
+
+impl<'a> Header<'a> {
+    pub fn new(theme: &'a Theme, frame_count: u64) -> Self {
+        Self { theme, frame_count }
+    }
+}
+
+impl Widget for Header<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        // Fill background
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if let Some(cell) = buf.cell_mut((x, y)) {
+                    cell.set_style(Style::default().bg(self.theme.background));
+                }
+            }
+        }
+
+        let text = format!("~ sexy-claude ~  v{}", env!("CARGO_PKG_VERSION"));
+        let text_len = text.len() as u16;
+
+        // Center on the middle row of the 3-row header
+        let mid_y = area.top() + HEADER_HEIGHT / 2;
+        let start_x = area.left() + area.width.saturating_sub(text_len) / 2;
+
+        let phase = self.frame_count as f64 * 0.04;
+
+        for (i, ch) in text.chars().enumerate() {
+            let x = start_x + i as u16;
+            if x >= area.right() {
+                break;
+            }
+            let position = (i as f64 / text_len.max(1) as f64) + phase;
+            let color = gradient_color(self.theme, position);
+            let style = Style::default()
+                .fg(color)
+                .bg(self.theme.background)
+                .add_modifier(Modifier::BOLD);
+            if let Some(cell) = buf.cell_mut((x, mid_y)) {
+                cell.set_char(ch);
+                cell.set_style(style);
+            }
+        }
+    }
+}
+
+/// Linearly interpolate between two RGB colors.
+pub fn lerp_color(a: Color, b: Color, t: f64) -> Color {
+    let t = t.clamp(0.0, 1.0);
+    match (a, b) {
+        (Color::Rgb(r1, g1, b1), Color::Rgb(r2, g2, b2)) => {
+            let r = (r1 as f64 + (r2 as f64 - r1 as f64) * t).round() as u8;
+            let g = (g1 as f64 + (g2 as f64 - g1 as f64) * t).round() as u8;
+            let b = (b1 as f64 + (b2 as f64 - b1 as f64) * t).round() as u8;
+            Color::Rgb(r, g, b)
+        }
+        _ => a,
+    }
+}
+
+/// Sample the 3-color gradient loop: primary -> secondary -> accent -> primary.
+/// `position` is an unbounded f64; the fractional part determines the color.
+pub fn gradient_color(theme: &Theme, position: f64) -> Color {
+    let t = position.rem_euclid(1.0) * 3.0;
+    let segment = t as usize;
+    let frac = t - segment as f64;
+
+    match segment {
+        0 => lerp_color(theme.primary, theme.secondary, frac),
+        1 => lerp_color(theme.secondary, theme.accent, frac),
+        _ => lerp_color(theme.accent, theme.primary, frac),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theme::Theme;
+
+    fn test_theme() -> Theme {
+        Theme::default_theme()
+    }
+
+    #[test]
+    fn test_lerp_color_endpoints() {
+        let a = Color::Rgb(0, 0, 0);
+        let b = Color::Rgb(255, 255, 255);
+        assert_eq!(lerp_color(a, b, 0.0), Color::Rgb(0, 0, 0));
+        assert_eq!(lerp_color(a, b, 1.0), Color::Rgb(255, 255, 255));
+    }
+
+    #[test]
+    fn test_lerp_color_midpoint() {
+        let a = Color::Rgb(0, 0, 0);
+        let b = Color::Rgb(200, 100, 50);
+        let mid = lerp_color(a, b, 0.5);
+        assert_eq!(mid, Color::Rgb(100, 50, 25));
+    }
+
+    #[test]
+    fn test_lerp_color_clamps() {
+        let a = Color::Rgb(100, 100, 100);
+        let b = Color::Rgb(200, 200, 200);
+        assert_eq!(lerp_color(a, b, -0.5), Color::Rgb(100, 100, 100));
+        assert_eq!(lerp_color(a, b, 1.5), Color::Rgb(200, 200, 200));
+    }
+
+    #[test]
+    fn test_gradient_color_at_zero() {
+        let theme = test_theme();
+        let color = gradient_color(&theme, 0.0);
+        assert_eq!(color, theme.primary);
+    }
+
+    #[test]
+    fn test_gradient_color_wraps() {
+        let theme = test_theme();
+        let a = gradient_color(&theme, 0.0);
+        let b = gradient_color(&theme, 1.0);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_header_renders_without_panic() {
+        let theme = test_theme();
+        let header = Header::new(&theme, 42);
+        let area = Rect::new(0, 0, 60, HEADER_HEIGHT);
+        let mut buf = Buffer::empty(area);
+        header.render(area, &mut buf);
+
+        // Check that the middle row has non-empty content
+        let mid_y = HEADER_HEIGHT / 2;
+        let row: String = (0..60).map(|x| buf.cell((x, mid_y)).unwrap().symbol().chars().next().unwrap_or(' ')).collect();
+        assert!(row.contains("sexy-claude"));
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 pub mod borders;
 pub mod claude_pane;
+pub mod header;
 pub mod input;
 pub mod status_bar;
 
@@ -8,6 +9,7 @@ use ratatui::Frame;
 
 use crate::theme::Theme;
 use claude_pane::ClaudePane;
+use header::{Header, HEADER_HEIGHT};
 use status_bar::StatusBar;
 
 /// Render the full UI layout.
@@ -15,24 +17,29 @@ pub fn render(
     frame: &mut Frame,
     screen: &vt100::Screen,
     theme: &Theme,
+    frame_count: u64,
 ) {
     let size = frame.area();
 
-    // Main vertical layout: [claude pane] [status bar]
+    // Main vertical layout: [header] [claude pane] [status bar]
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(3),   // Claude pane (fills remaining)
-            Constraint::Length(1), // Status bar
+            Constraint::Length(HEADER_HEIGHT), // Animated header
+            Constraint::Min(3),               // Claude pane (fills remaining)
+            Constraint::Length(1),             // Status bar
         ])
         .split(size);
 
-    // Claude pane with themed border
-    let claude_block = borders::themed_block(" sexy-claude ", true, theme);
-    let claude_inner = claude_block.inner(chunks[0]);
-    frame.render_widget(claude_block, chunks[0]);
+    // Animated header
+    frame.render_widget(Header::new(theme, frame_count), chunks[0]);
+
+    // Claude pane with themed border (no title — header handles branding)
+    let claude_block = borders::themed_block("", true, theme);
+    let claude_inner = claude_block.inner(chunks[1]);
+    frame.render_widget(claude_block, chunks[1]);
     frame.render_widget(ClaudePane::new(screen, theme.background), claude_inner);
 
     // Status bar
-    frame.render_widget(StatusBar::new(&theme.name, theme), chunks[1]);
+    frame.render_widget(StatusBar::new(&theme.name, theme), chunks[2]);
 }


### PR DESCRIPTION
## Summary
- Add VS Code-style **action menu** (Ctrl+K) with filterable overlay popup
- Add **theme picker** (Ctrl+T) with live preview as you navigate
- Persist selected theme to `~/.config/sexy-claude/config.toml`
- Add **9 new bundled themes**: Tokyo Night, Monokai Pro, Dracula, Gruvbox Dark, Nord, One Dark, Rosé Pine, Solarized Dark, Kanagawa
- Add animated gradient header widget
- Add reusable overlay widget system (centered popup with filter input, scrollable list, keyboard navigation)

Closes #1 (Theme switcher)
Closes #4 (More default themes)  
Closes #5 (Keybindings menu)

## New keybindings
| Shortcut | Action |
|----------|--------|
| Ctrl+K | Open action menu |
| Ctrl+T | Open theme picker |
| Ctrl+Q | Quit |

## Test plan
- [x] `cargo test` — 50 unit tests + 10 integration tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo build --release` — compiles
- [ ] Manual: Ctrl+T opens theme picker, arrow keys navigate with live preview
- [ ] Manual: Enter confirms theme, Escape reverts
- [ ] Manual: Ctrl+K opens action menu, selecting "Switch Theme" opens picker
- [ ] Manual: Type to filter themes in picker
- [ ] Manual: Selected theme persists in config.toml across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)