### PR TITLE
feat: add slash command support and fix message whitespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "unicode-width 0.2.0",
  "vt100",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 anyhow = "1"
+unicode-width = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/claude/conversation.rs
+++ b/src/claude/conversation.rs
@@ -133,8 +133,19 @@ impl Conversation {
                 self.streaming = false;
             }
 
-            StreamEvent::Unknown(_) => {
-                // Ignored.
+            StreamEvent::Result { ref text, .. } => {
+                // Slash command results appear as assistant messages.
+                if !text.is_empty() {
+                    self.messages.push(Message {
+                        role: Role::Assistant,
+                        content: vec![ContentBlock::Text(text.clone())],
+                    });
+                }
+                self.streaming = false;
+            }
+
+            StreamEvent::SystemInit { .. } | StreamEvent::Unknown(_) => {
+                // Handled by App, not conversation state.
             }
         }
     }

--- a/src/claude/process.rs
+++ b/src/claude/process.rs
@@ -19,7 +19,16 @@ impl ClaudeProcess {
 
         let mut cmd = Command::new(program);
         cmd.args(args);
-        cmd.args(["-p", "--output-format", "stream-json", "--input-format", "stream-json"]);
+        cmd.args([
+            "-p",
+            "--output-format", "stream-json",
+            "--input-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+        ]);
+        // Prevent "cannot run inside another Claude Code session" error
+        cmd.env_remove("CLAUDECODE");
+        cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
         cmd.stdin(std::process::Stdio::piped());
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
@@ -49,8 +58,11 @@ impl ClaudeProcess {
     /// Send a user message as a stream-json input event.
     pub async fn send_message(&mut self, text: &str) -> Result<()> {
         let event = serde_json::json!({
-            "type": "user_input",
-            "content": text,
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": text,
+            },
         });
         let mut line = serde_json::to_string(&event)?;
         line.push('\n');

--- a/src/ui/claude_pane.rs
+++ b/src/ui/claude_pane.rs
@@ -2,6 +2,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::Widget;
+use unicode_width::UnicodeWidthChar;
 
 use crate::claude::conversation::{ContentBlock, Conversation, Message, Role};
 use crate::theme::Theme;
@@ -42,8 +43,8 @@ impl Widget for ClaudePane<'_> {
             }
         }
 
-        // Convert conversation to lines
-        let lines = render_conversation(self.conversation, area.width as usize);
+        // Convert conversation to wrapped lines
+        let lines = render_conversation(self.conversation, area.width as usize, self.theme);
 
         // Apply scroll offset
         let visible_lines: Vec<&StyledLine> = lines
@@ -60,14 +61,28 @@ impl Widget for ClaudePane<'_> {
             let mut x = area.left();
             for span in &line.spans {
                 for ch in span.text.chars() {
-                    if x >= area.right() {
+                    let ch_width = ch.width().unwrap_or(0);
+                    if ch_width == 0 {
+                        continue;
+                    }
+                    if x + ch_width as u16 > area.right() {
                         break;
                     }
                     if let Some(cell) = buf.cell_mut((x, y)) {
                         cell.set_char(ch);
                         cell.set_style(span.style.bg(bg));
                     }
-                    x += 1;
+                    // For wide chars (emoji etc), blank the next cell so ratatui doesn't clobber
+                    if ch_width == 2 {
+                        let next_x = x + 1;
+                        if next_x < area.right() {
+                            if let Some(cell) = buf.cell_mut((next_x, y)) {
+                                cell.set_char(' ');
+                                cell.set_style(span.style.bg(bg));
+                            }
+                        }
+                    }
+                    x += ch_width as u16;
                 }
             }
         }
@@ -100,47 +115,97 @@ impl StyledLine {
     }
 }
 
-/// Convert the entire conversation into styled lines for rendering.
-fn render_conversation(conversation: &Conversation, _width: usize) -> Vec<StyledLine> {
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const USER_PREFIX: &str = "  You  ";
+const ASSISTANT_PREFIX: &str = " Claude ";
+
+fn user_label_style() -> Style {
+    Style::default()
+        .fg(Color::Rgb(30, 30, 46))
+        .bg(Color::Rgb(137, 180, 250))
+        .add_modifier(Modifier::BOLD)
+}
+
+fn assistant_label_style() -> Style {
+    Style::default()
+        .fg(Color::Rgb(30, 30, 46))
+        .bg(Color::Rgb(166, 227, 161))
+        .add_modifier(Modifier::BOLD)
+}
+
+fn user_text_style() -> Style {
+    Style::default().fg(Color::Rgb(205, 214, 244))
+}
+
+fn separator_style() -> Style {
+    Style::default().fg(Color::Rgb(69, 71, 90))
+}
+
+// ---------------------------------------------------------------------------
+// Conversation → lines
+// ---------------------------------------------------------------------------
+
+/// Convert the entire conversation into styled, wrapped lines for rendering.
+fn render_conversation(conversation: &Conversation, width: usize, theme: &Theme) -> Vec<StyledLine> {
     let mut lines = Vec::new();
+    let content_width = width.saturating_sub(2); // 2-char left padding
 
     for (i, msg) in conversation.messages.iter().enumerate() {
         if i > 0 {
-            lines.push(StyledLine::empty());
+            // Separator line between messages
+            let sep = "─".repeat(width.min(120));
+            lines.push(StyledLine::plain(&sep, separator_style()));
         }
-        render_message(msg, &mut lines);
+        render_message(msg, &mut lines, content_width, theme);
     }
 
     lines
 }
 
-fn render_message(msg: &Message, lines: &mut Vec<StyledLine>) {
-    let (prefix, prefix_style) = match msg.role {
-        Role::User => (
-            "> ",
-            Style::default()
-                .fg(Color::Rgb(137, 180, 250))
-                .add_modifier(Modifier::BOLD),
-        ),
-        Role::Assistant => (
-            "",
-            Style::default().fg(Color::Rgb(166, 227, 161)),
-        ),
+fn render_message(msg: &Message, lines: &mut Vec<StyledLine>, content_width: usize, theme: &Theme) {
+    // Role label line
+    match msg.role {
+        Role::User => {
+            lines.push(StyledLine {
+                spans: vec![StyledSpan {
+                    text: USER_PREFIX.to_string(),
+                    style: user_label_style(),
+                }],
+            });
+        }
+        Role::Assistant => {
+            lines.push(StyledLine {
+                spans: vec![StyledSpan {
+                    text: ASSISTANT_PREFIX.to_string(),
+                    style: assistant_label_style(),
+                }],
+            });
+        }
+    }
+
+    let text_style = match msg.role {
+        Role::User => user_text_style(),
+        Role::Assistant => Style::default().fg(theme.secondary),
     };
 
     for block in &msg.content {
         match block {
             ContentBlock::Text(text) => {
-                render_text_block(text, prefix, prefix_style, lines);
+                // Trim leading blank lines to avoid whitespace gap after role label
+                let trimmed = text.trim_start_matches('\n');
+                render_text_block(trimmed, text_style, lines, content_width);
             }
             ContentBlock::ToolUse { name, input, .. } => {
                 let tool_style = Style::default()
                     .fg(Color::Rgb(249, 226, 175))
                     .add_modifier(Modifier::DIM);
                 let summary = if input.len() > 60 {
-                    format!("[{}] {}...", name, &input[..57])
+                    format!("  [{name}] {}...", &input[..57])
                 } else {
-                    format!("[{}] {}", name, input)
+                    format!("  [{name}] {input}")
                 };
                 lines.push(StyledLine::plain(&summary, tool_style));
             }
@@ -148,104 +213,262 @@ fn render_message(msg: &Message, lines: &mut Vec<StyledLine>) {
     }
 }
 
-/// Render a text block with basic formatting: **bold**, `code`, ```code blocks```, # headers.
+/// Render a text block with basic formatting and word wrapping.
 fn render_text_block(
     text: &str,
-    prefix: &str,
-    prefix_style: Style,
+    base_style: Style,
     lines: &mut Vec<StyledLine>,
+    content_width: usize,
 ) {
-    let text_style = Style::default().fg(Color::Rgb(205, 214, 244));
-    let bold_style = text_style.add_modifier(Modifier::BOLD);
+    let bold_style = base_style.add_modifier(Modifier::BOLD);
     let code_style = Style::default().fg(Color::Rgb(166, 227, 161));
     let code_block_style = Style::default().fg(Color::Rgb(180, 190, 220));
     let header_style = Style::default()
         .fg(Color::Rgb(203, 166, 247))
         .add_modifier(Modifier::BOLD);
 
+    let indent = "  "; // 2-char indent for message body
     let mut in_code_block = false;
 
-    for (line_idx, raw_line) in text.lines().enumerate() {
+    for raw_line in text.lines() {
         // Code block fence
         if raw_line.trim_start().starts_with("```") {
             in_code_block = !in_code_block;
             let fence_style = Style::default()
                 .fg(Color::Rgb(127, 132, 156))
                 .add_modifier(Modifier::DIM);
-            lines.push(StyledLine::plain(raw_line, fence_style));
+            lines.push(StyledLine::plain(&format!("{indent}{raw_line}"), fence_style));
             continue;
         }
 
         if in_code_block {
-            lines.push(StyledLine::plain(raw_line, code_block_style));
+            // Code blocks: preserve exact formatting, just indent
+            lines.push(StyledLine::plain(
+                &format!("{indent}{raw_line}"),
+                code_block_style,
+            ));
             continue;
         }
 
         // Headers
         if raw_line.starts_with('#') {
-            lines.push(StyledLine::plain(raw_line, header_style));
+            lines.push(StyledLine::plain(
+                &format!("{indent}{raw_line}"),
+                header_style,
+            ));
             continue;
         }
 
-        // Normal text with inline formatting
-        let effective_prefix = if line_idx == 0 { prefix } else { "" };
-        let mut spans = Vec::new();
-
-        if !effective_prefix.is_empty() {
-            spans.push(StyledSpan {
-                text: effective_prefix.to_string(),
-                style: prefix_style,
-            });
+        // Empty line
+        if raw_line.is_empty() {
+            lines.push(StyledLine::empty());
+            continue;
         }
 
-        // Simple inline parsing: **bold** and `code`
-        let mut remaining = raw_line;
-        while !remaining.is_empty() {
-            if remaining.starts_with("**") {
-                if let Some(end) = remaining[2..].find("**") {
-                    spans.push(StyledSpan {
-                        text: remaining[2..2 + end].to_string(),
-                        style: bold_style,
-                    });
-                    remaining = &remaining[2 + end + 2..];
-                    continue;
-                }
-            }
-            if remaining.starts_with('`') {
-                if let Some(end) = remaining[1..].find('`') {
-                    spans.push(StyledSpan {
-                        text: remaining[1..1 + end].to_string(),
-                        style: code_style,
-                    });
-                    remaining = &remaining[1 + end + 1..];
-                    continue;
-                }
-            }
-            let next_special = remaining
-                .find(['*', '`'])
-                .unwrap_or(remaining.len());
-            if next_special > 0 {
-                spans.push(StyledSpan {
-                    text: remaining[..next_special].to_string(),
-                    style: text_style,
-                });
-                remaining = &remaining[next_special..];
-            } else {
-                spans.push(StyledSpan {
-                    text: remaining[..1].to_string(),
-                    style: text_style,
-                });
-                remaining = &remaining[1..];
-            }
-        }
-
-        lines.push(StyledLine { spans });
+        // Normal text with inline formatting — parse into spans then wrap
+        let parsed_spans = parse_inline_formatting(raw_line, base_style, bold_style, code_style);
+        wrap_spans(&parsed_spans, indent, lines, content_width);
     }
 }
 
+/// Parse inline formatting (**bold**, `code`) into styled spans.
+fn parse_inline_formatting(
+    text: &str,
+    text_style: Style,
+    bold_style: Style,
+    code_style: Style,
+) -> Vec<StyledSpan> {
+    let mut spans = Vec::new();
+    let mut remaining = text;
+
+    while !remaining.is_empty() {
+        if remaining.starts_with("**") {
+            if let Some(end) = remaining[2..].find("**") {
+                spans.push(StyledSpan {
+                    text: remaining[2..2 + end].to_string(),
+                    style: bold_style,
+                });
+                remaining = &remaining[2 + end + 2..];
+                continue;
+            }
+        }
+        if remaining.starts_with('`') {
+            if let Some(end) = remaining[1..].find('`') {
+                spans.push(StyledSpan {
+                    text: remaining[1..1 + end].to_string(),
+                    style: code_style,
+                });
+                remaining = &remaining[1 + end + 1..];
+                continue;
+            }
+        }
+        let next_special = remaining
+            .find(['*', '`'])
+            .unwrap_or(remaining.len());
+        if next_special > 0 {
+            spans.push(StyledSpan {
+                text: remaining[..next_special].to_string(),
+                style: text_style,
+            });
+            remaining = &remaining[next_special..];
+        } else {
+            spans.push(StyledSpan {
+                text: remaining[..1].to_string(),
+                style: text_style,
+            });
+            remaining = &remaining[1..];
+        }
+    }
+
+    spans
+}
+
+/// Word-wrap a list of styled spans to fit within `max_width`, prepending `indent` to each line.
+fn wrap_spans(
+    spans: &[StyledSpan],
+    indent: &str,
+    lines: &mut Vec<StyledLine>,
+    max_width: usize,
+) {
+    let indent_width = display_width(indent);
+    let available = max_width.saturating_sub(indent_width);
+    if available == 0 {
+        return;
+    }
+
+    let mut current_line_spans: Vec<StyledSpan> = vec![StyledSpan {
+        text: indent.to_string(),
+        style: Style::default(),
+    }];
+    let mut current_width: usize = 0;
+
+    for span in spans {
+        let mut remaining = span.text.as_str();
+
+        while !remaining.is_empty() {
+            let rem_width = display_width(remaining);
+
+            // If the remaining text fits on the current line, add it
+            if current_width + rem_width <= available {
+                current_line_spans.push(StyledSpan {
+                    text: remaining.to_string(),
+                    style: span.style,
+                });
+                current_width += rem_width;
+                break;
+            }
+
+            // Find a word-break point
+            let budget = available.saturating_sub(current_width);
+            let (chunk, rest) = split_at_width_word_boundary(remaining, budget);
+
+            if chunk.is_empty() {
+                // Current line has no room — flush and start new line
+                lines.push(StyledLine {
+                    spans: std::mem::take(&mut current_line_spans),
+                });
+                current_line_spans.push(StyledSpan {
+                    text: indent.to_string(),
+                    style: Style::default(),
+                });
+                current_width = 0;
+
+                // If the remaining text doesn't fit even on a fresh line, force-break by chars
+                if display_width(rest) == display_width(remaining) && !remaining.is_empty() {
+                    let (forced, forced_rest) = split_at_width(remaining, available);
+                    if !forced.is_empty() {
+                        current_line_spans.push(StyledSpan {
+                            text: forced.to_string(),
+                            style: span.style,
+                        });
+                    }
+                    remaining = forced_rest;
+                    lines.push(StyledLine {
+                        spans: std::mem::take(&mut current_line_spans),
+                    });
+                    current_line_spans.push(StyledSpan {
+                        text: indent.to_string(),
+                        style: Style::default(),
+                    });
+                    current_width = 0;
+                    continue;
+                }
+                remaining = rest;
+            } else {
+                current_line_spans.push(StyledSpan {
+                    text: chunk.to_string(),
+                    style: span.style,
+                });
+                lines.push(StyledLine {
+                    spans: std::mem::take(&mut current_line_spans),
+                });
+                current_line_spans.push(StyledSpan {
+                    text: indent.to_string(),
+                    style: Style::default(),
+                });
+                current_width = 0;
+                remaining = rest.trim_start();
+            }
+        }
+    }
+
+    // Flush remaining line
+    if current_line_spans.len() > 1 || current_width > 0 {
+        lines.push(StyledLine {
+            spans: current_line_spans,
+        });
+    }
+}
+
+/// Calculate display width of a string (accounting for wide chars like emoji).
+fn display_width(s: &str) -> usize {
+    s.chars()
+        .map(|c| c.width().unwrap_or(0))
+        .sum()
+}
+
+/// Split a string at approximately `max_width` display columns, preferring word boundaries.
+/// Returns (chunk_that_fits, remainder).
+fn split_at_width_word_boundary(s: &str, max_width: usize) -> (&str, &str) {
+    let mut width = 0;
+    let mut last_space_byte = 0;
+    let mut byte_pos = 0;
+
+    for (i, ch) in s.char_indices() {
+        let ch_w = ch.width().unwrap_or(0);
+        if width + ch_w > max_width {
+            // Use word boundary if we found a space
+            if last_space_byte > 0 {
+                return (&s[..last_space_byte], s[last_space_byte..].trim_start());
+            }
+            return (&s[..byte_pos], &s[byte_pos..]);
+        }
+        if ch == ' ' {
+            last_space_byte = i + 1; // include the space in the chunk
+        }
+        width += ch_w;
+        byte_pos = i + ch.len_utf8();
+    }
+
+    (s, "")
+}
+
+/// Split a string at exactly `max_width` display columns (force break, no word boundary).
+fn split_at_width(s: &str, max_width: usize) -> (&str, &str) {
+    let mut width = 0;
+    for (i, ch) in s.char_indices() {
+        let ch_w = ch.width().unwrap_or(0);
+        if width + ch_w > max_width {
+            return (&s[..i], &s[i..]);
+        }
+        width += ch_w;
+    }
+    (s, "")
+}
+
 /// Calculate total number of rendered lines for scroll calculations.
-pub fn total_lines(conversation: &Conversation, width: usize) -> usize {
-    render_conversation(conversation, width).len()
+pub fn total_lines(conversation: &Conversation, width: usize, theme: &Theme) -> usize {
+    render_conversation(conversation, width, theme).len()
 }
 
 #[cfg(test)]
@@ -264,33 +487,49 @@ mod tests {
     }
 
     #[test]
-    fn test_user_message_has_prefix() {
+    fn test_user_message_has_label() {
         let mut conv = Conversation::new();
+        let theme = crate::theme::Theme::default_theme();
         conv.push_user_message("Hello".to_string());
-        let lines = render_conversation(&conv, 80);
+        let lines = render_conversation(&conv, 80, &theme);
         assert!(!lines.is_empty());
-        let first_line = &lines[0];
-        let text: String = first_line.spans.iter().map(|s| s.text.as_str()).collect();
-        assert!(text.starts_with("> "));
-        assert!(text.contains("Hello"));
+        let label: String = lines[0].spans.iter().map(|s| s.text.as_str()).collect();
+        assert!(label.contains("You"));
+    }
+
+    #[test]
+    fn test_assistant_message_has_label() {
+        let mut conv = Conversation::new();
+        let theme = crate::theme::Theme::default_theme();
+        conv.messages.push(Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Text("Hi there".to_string())],
+        });
+        let lines = render_conversation(&conv, 80, &theme);
+        assert!(!lines.is_empty());
+        let label: String = lines[0].spans.iter().map(|s| s.text.as_str()).collect();
+        assert!(label.contains("Claude"));
     }
 
     #[test]
     fn test_code_block_rendering() {
         let mut conv = Conversation::new();
+        let theme = crate::theme::Theme::default_theme();
         conv.messages.push(Message {
             role: Role::Assistant,
             content: vec![ContentBlock::Text(
                 "Here is code:\n```rust\nfn main() {}\n```\nDone.".to_string(),
             )],
         });
-        let lines = render_conversation(&conv, 80);
-        assert!(lines.len() >= 5);
+        let lines = render_conversation(&conv, 80, &theme);
+        // label + code fence + code + code fence + "Done." + blank = at least 6 lines
+        assert!(lines.len() >= 6);
     }
 
     #[test]
     fn test_tool_use_rendering() {
         let mut conv = Conversation::new();
+        let theme = crate::theme::Theme::default_theme();
         conv.messages.push(Message {
             role: Role::Assistant,
             content: vec![ContentBlock::ToolUse {
@@ -299,9 +538,52 @@ mod tests {
                 input: "{\"command\":\"ls\"}".to_string(),
             }],
         });
-        let lines = render_conversation(&conv, 80);
-        let text: String = lines[0].spans.iter().map(|s| s.text.as_str()).collect();
-        assert!(text.contains("[Bash]"));
+        let lines = render_conversation(&conv, 80, &theme);
+        let all_text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.text.as_str())
+            .collect();
+        assert!(all_text.contains("[Bash]"));
+    }
+
+    #[test]
+    fn test_word_wrapping() {
+        let long_text = "This is a very long sentence that should be word wrapped when the terminal width is narrow enough to force it onto multiple lines";
+        let mut conv = Conversation::new();
+        let theme = crate::theme::Theme::default_theme();
+        conv.messages.push(Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Text(long_text.to_string())],
+        });
+        // Narrow width to force wrapping
+        let lines = render_conversation(&conv, 40, &theme);
+        // Should produce multiple lines (label + wrapped text + blank)
+        assert!(lines.len() > 3, "Expected wrapping, got {} lines", lines.len());
+    }
+
+    #[test]
+    fn test_display_width() {
+        assert_eq!(display_width("hello"), 5);
+        assert_eq!(display_width(""), 0);
+    }
+
+    #[test]
+    fn test_separator_between_messages() {
+        let mut conv = Conversation::new();
+        let theme = crate::theme::Theme::default_theme();
+        conv.push_user_message("Hi".to_string());
+        conv.messages.push(Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Text("Hello!".to_string())],
+        });
+        let lines = render_conversation(&conv, 80, &theme);
+        let all_text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.text.as_str())
+            .collect();
+        assert!(all_text.contains("─"), "Expected separator line");
     }
 
     #[test]

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -95,6 +95,12 @@ impl InputEditor {
         content
     }
 
+    /// Replace the entire content and move cursor to end.
+    pub fn set_content(&mut self, text: &str) {
+        self.content = text.to_string();
+        self.cursor = self.content.len();
+    }
+
     pub fn is_empty(&self) -> bool {
         self.content.is_empty()
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,9 +5,14 @@ pub mod input;
 pub mod overlay;
 pub mod status_bar;
 
-use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::symbols::border;
+use ratatui::widgets::{Block, Borders, Clear, Widget};
 use ratatui::Frame;
 
+use crate::app::CompletionState;
 use crate::claude::conversation::Conversation;
 use crate::theme::Theme;
 use claude_pane::ClaudePane;
@@ -17,6 +22,7 @@ use overlay::{OverlayState, OverlayWidget};
 use status_bar::StatusBar;
 
 /// Render the full UI layout.
+#[allow(clippy::too_many_arguments)]
 pub fn render(
     frame: &mut Frame,
     conversation: &Conversation,
@@ -25,6 +31,7 @@ pub fn render(
     frame_count: u64,
     scroll_offset: usize,
     is_streaming: bool,
+    completion: Option<&CompletionState>,
 ) {
     let size = frame.area();
 
@@ -63,8 +70,92 @@ pub fn render(
     frame.render_widget(input_block, chunks[2]);
     frame.render_widget(InputWidget::new(input, theme), input_inner);
 
+    // Completion popup (rendered above input area)
+    if let Some(state) = completion {
+        render_completion_popup(frame.buffer_mut(), state, chunks[2], theme);
+    }
+
     // Status bar
     frame.render_widget(StatusBar::new(&theme.name, theme), chunks[3]);
+}
+
+/// Render the slash command completion popup just above the input area.
+fn render_completion_popup(buf: &mut Buffer, state: &CompletionState, input_area: Rect, theme: &Theme) {
+    if state.matches.is_empty() {
+        return;
+    }
+
+    let max_visible = 8usize.min(state.matches.len());
+    let popup_height = max_visible as u16 + 2; // +2 for borders
+    let popup_width = 40u16.min(input_area.width);
+
+    // Position popup just above the input area
+    let popup_y = input_area.y.saturating_sub(popup_height);
+    let popup_x = input_area.x + 1;
+    let popup = Rect::new(popup_x, popup_y, popup_width, popup_height);
+
+    // Clear area behind popup
+    Clear.render(popup, buf);
+
+    // Draw border
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_set(border::ROUNDED)
+        .border_style(Style::default().fg(theme.border_focused))
+        .style(Style::default().bg(theme.surface).fg(theme.foreground));
+
+    let inner = block.inner(popup);
+    block.render(popup, buf);
+
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
+
+    // Scroll to keep selected visible
+    let scroll = if state.selected >= max_visible {
+        state.selected - max_visible + 1
+    } else {
+        0
+    };
+
+    for (vi, cmd) in state.matches.iter().skip(scroll).take(max_visible).enumerate() {
+        let y = inner.y + vi as u16;
+        if y >= inner.bottom() {
+            break;
+        }
+
+        let is_selected = vi + scroll == state.selected;
+        let style = if is_selected {
+            Style::default()
+                .fg(theme.primary)
+                .bg(theme.overlay)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.foreground).bg(theme.surface)
+        };
+
+        // Fill row background
+        for x in inner.x..inner.right() {
+            if let Some(cell) = buf.cell_mut((x, y)) {
+                cell.set_char(' ');
+                cell.set_style(style);
+            }
+        }
+
+        // Write the command with / prefix
+        let marker = if is_selected { " ▸ " } else { "   " };
+        let text = format!("{marker}/{cmd}");
+        for (i, ch) in text.chars().enumerate() {
+            let x = inner.x + i as u16;
+            if x >= inner.right() {
+                break;
+            }
+            if let Some(cell) = buf.cell_mut((x, y)) {
+                cell.set_char(ch);
+                cell.set_style(style);
+            }
+        }
+    }
 }
 
 /// Render an overlay popup on top of the existing UI.


### PR DESCRIPTION
## Summary
- **Parse `result` events** from Claude CLI so slash commands (`/compact`, `/cost`, `/review`, etc.) display their output instead of being silently dropped
- **Route slash commands** to Claude without adding them as user conversation messages; handle `/clear` locally to reset conversation state
- **Fix whitespace** by trimming leading blank lines from assistant text blocks, removing the gap between role labels and message content

## Test plan
- [ ] Run `cargo test` — all 87 unit tests + integration tests pass
- [ ] Launch `sc`, type `/cost` — should display cost info from Claude
- [ ] Launch `sc`, type `/compact` — should trigger context compaction
- [ ] Launch `sc`, type `/clear` — conversation should reset
- [ ] Verify assistant messages no longer have extra whitespace after the "Claude" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)