### PR TITLE
feat: fix bugs, redesign plugin modal, add CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Format check
+        run: cargo fmt --check
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+      - name: Build
+        run: cargo build
+      - name: Test
+        run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: sexy-claude-linux-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: sexy-claude-macos-aarch64
+          - os: macos-13
+            target: x86_64-apple-darwin
+            artifact: sexy-claude-macos-x86_64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Build release
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Package binaries
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/sexy-claude dist/ 2>/dev/null || true
+          cp target/${{ matrix.target }}/release/sc dist/ 2>/dev/null || true
+          cd dist && tar czf ../${{ matrix.artifact }}.tar.gz *
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.tar.gz
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG_NAME" \
+            --generate-notes \
+            artifacts/*.tar.gz

--- a/src/claude/conversation.rs
+++ b/src/claude/conversation.rs
@@ -92,14 +92,6 @@ impl Conversation {
         });
     }
 
-    /// Add a system/info message displayed as an assistant message.
-    pub fn push_system_message(&mut self, text: String) {
-        self.messages.push(Message {
-            role: Role::Assistant,
-            content: vec![ContentBlock::Text(text)],
-        });
-    }
-
     /// Process a single stream event, updating the conversation state.
     pub fn apply_event(&mut self, event: &StreamEvent) {
         match event {
@@ -579,7 +571,10 @@ mod tests {
         conv.apply_event(&StreamEvent::ContentBlockStop { index: 0 });
 
         // 30-line output should auto-collapse
-        let long_output = (0..30).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");
+        let long_output = (0..30)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
         conv.apply_event(&StreamEvent::ToolResult {
             tool_use_id: "toolu_long".to_string(),
             content: long_output,

--- a/src/claude/mod.rs
+++ b/src/claude/mod.rs
@@ -1,5 +1,5 @@
 pub mod commands;
+pub mod conversation;
 pub mod events;
 pub mod process;
-pub mod conversation;
 pub mod sessions;

--- a/src/claude/process.rs
+++ b/src/claude/process.rs
@@ -32,26 +32,6 @@ pub struct ClaudeProcess {
 }
 
 impl ClaudeProcess {
-    /// Spawn claude in print mode with stream-json I/O.
-    /// Returns the process handle and a receiver for parsed events.
-    pub fn spawn(command: &str) -> Result<(Self, mpsc::UnboundedReceiver<StreamEvent>)> {
-        Self::spawn_with_options(command, SpawnOptions::default())
-    }
-
-    /// Spawn claude resuming an existing session.
-    pub fn spawn_with_resume(
-        command: &str,
-        session_id: &str,
-    ) -> Result<(Self, mpsc::UnboundedReceiver<StreamEvent>)> {
-        Self::spawn_with_options(
-            command,
-            SpawnOptions {
-                resume_session_id: Some(session_id.to_string()),
-                ..Default::default()
-            },
-        )
-    }
-
     /// Spawn claude continuing the most recent session.
     pub fn spawn_with_continue(
         command: &str,
@@ -77,8 +57,10 @@ impl ClaudeProcess {
         cmd.args(args);
         cmd.args([
             "-p",
-            "--output-format", "stream-json",
-            "--input-format", "stream-json",
+            "--output-format",
+            "stream-json",
+            "--input-format",
+            "stream-json",
             "--verbose",
             "--include-partial-messages",
         ]);
@@ -115,7 +97,9 @@ impl ClaudeProcess {
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
 
-        let mut child = cmd.spawn().with_context(|| format!("Failed to spawn '{}'", command))?;
+        let mut child = cmd
+            .spawn()
+            .with_context(|| format!("Failed to spawn '{}'", command))?;
 
         let stdin = child.stdin.take().context("Failed to get stdin")?;
         let stdout = child.stdout.take().context("Failed to get stdout")?;
@@ -167,7 +151,10 @@ impl ClaudeProcess {
 
     /// Kill the child process.
     pub async fn kill(&mut self) -> Result<()> {
-        self.child.kill().await.context("Failed to kill claude process")
+        self.child
+            .kill()
+            .await
+            .context("Failed to kill claude process")
     }
 }
 
@@ -185,7 +172,10 @@ mod tests {
     fn test_spawn_nonexistent_command_fails() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
-            let result = ClaudeProcess::spawn("nonexistent_command_xyz_12345");
+            let result = ClaudeProcess::spawn_with_options(
+                "nonexistent_command_xyz_12345",
+                SpawnOptions::default(),
+            );
             assert!(result.is_err());
         });
     }

--- a/src/claude/sessions.rs
+++ b/src/claude/sessions.rs
@@ -119,8 +119,7 @@ fn extract_preview(path: &PathBuf) -> String {
                         if let Some(arr) = content.as_array() {
                             for block in arr {
                                 if block.get("type").and_then(|t| t.as_str()) == Some("text") {
-                                    if let Some(text) = block.get("text").and_then(|t| t.as_str())
-                                    {
+                                    if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
                                         return truncate_preview(text);
                                     }
                                 }
@@ -185,10 +184,7 @@ mod tests {
 
     #[test]
     fn test_truncate_preview_multiline() {
-        assert_eq!(
-            truncate_preview("First line\nSecond line"),
-            "First line"
-        );
+        assert_eq!(truncate_preview("First line\nSecond line"), "First line");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,7 +83,10 @@ impl Config {
     }
 
     fn validate(&self) -> Result<()> {
-        anyhow::ensure!(self.fps >= 1 && self.fps <= 120, "fps must be between 1 and 120");
+        anyhow::ensure!(
+            self.fps >= 1 && self.fps <= 120,
+            "fps must be between 1 and 120"
+        );
         anyhow::ensure!(
             self.layout.claude_pane_percent >= 20 && self.layout.claude_pane_percent <= 100,
             "claude_pane_percent must be between 20 and 100"
@@ -116,8 +119,7 @@ pub fn save_theme(theme_name: &str, path: &std::path::Path) -> Result<()> {
             .with_context(|| format!("Failed to create config directory {}", parent.display()))?;
     }
 
-    let content = toml::to_string_pretty(&table)
-        .context("Failed to serialize config")?;
+    let content = toml::to_string_pretty(&table).context("Failed to serialize config")?;
     std::fs::write(path, content)
         .with_context(|| format!("Failed to write config to {}", path.display()))?;
 
@@ -244,7 +246,11 @@ mod tests {
     fn test_save_theme_preserves_other_fields() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
-        std::fs::write(&path, "command = \"custom-claude\"\ntheme = \"old\"\nfps = 60\n").unwrap();
+        std::fs::write(
+            &path,
+            "command = \"custom-claude\"\ntheme = \"old\"\nfps = 60\n",
+        )
+        .unwrap();
         save_theme("dracula", &path).unwrap();
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("theme = \"dracula\""));

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -1,5 +1,4 @@
 /// Model pricing and cost calculation for token usage.
-
 /// Pricing per 1M tokens for a given model.
 #[derive(Debug, Clone, Copy)]
 pub struct ModelPricing {

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -179,11 +179,7 @@ mod tests {
         let ops = diff_lines("a\nc", "a\nb\nc");
         assert_eq!(
             ops,
-            vec![
-                DiffOp::Equal("a"),
-                DiffOp::Add("b"),
-                DiffOp::Equal("c"),
-            ]
+            vec![DiffOp::Equal("a"), DiffOp::Add("b"), DiffOp::Equal("c"),]
         );
     }
 
@@ -192,11 +188,7 @@ mod tests {
         let ops = diff_lines("a\nb\nc", "a\nc");
         assert_eq!(
             ops,
-            vec![
-                DiffOp::Equal("a"),
-                DiffOp::Remove("b"),
-                DiffOp::Equal("c"),
-            ]
+            vec![DiffOp::Equal("a"), DiffOp::Remove("b"), DiffOp::Equal("c"),]
         );
     }
 
@@ -247,7 +239,10 @@ mod tests {
         let new = "{\n    a\n}\n{\n    c\n}";
         let ops = diff_lines(old, new);
         // Should only show b→c change, not match braces incorrectly
-        let changes: Vec<_> = ops.iter().filter(|o| !matches!(o, DiffOp::Equal(_))).collect();
+        let changes: Vec<_> = ops
+            .iter()
+            .filter(|o| !matches!(o, DiffOp::Equal(_)))
+            .collect();
         assert_eq!(changes.len(), 2); // Remove "    b", Add "    c"
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -20,7 +20,11 @@ impl GitInfo {
             .filter(|o| o.status.success())
             .and_then(|o| {
                 let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
-                if s.is_empty() { None } else { Some(s) }
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s)
+                }
             });
 
         let dirty_count = Command::new("git")

--- a/src/history.rs
+++ b/src/history.rs
@@ -94,7 +94,13 @@ impl InputHistory {
 
         if query.is_empty() {
             // Return all entries, most recent first
-            return self.entries.iter().rev().enumerate().map(|(i, e)| (i, e.as_str())).collect();
+            return self
+                .entries
+                .iter()
+                .rev()
+                .enumerate()
+                .map(|(i, e)| (i, e.as_str()))
+                .collect();
         }
 
         let matcher = SkimMatcherV2::default();
@@ -111,7 +117,10 @@ impl InputHistory {
             .collect();
 
         matches.sort_by(|a, b| b.0.cmp(&a.0));
-        matches.into_iter().map(|(_, idx, entry)| (idx, entry)).collect()
+        matches
+            .into_iter()
+            .map(|(_, idx, entry)| (idx, entry))
+            .collect()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,10 @@ use clap::Parser;
 use std::path::PathBuf;
 
 #[derive(Parser)]
-#[command(name = "sexy-claude", about = "A beautiful terminal wrapper for Claude Code")]
+#[command(
+    name = "sexy-claude",
+    about = "A beautiful terminal wrapper for Claude Code"
+)]
 #[command(version)]
 struct Cli {
     /// Theme name (e.g., catppuccin-mocha, nord, dracula)
@@ -73,8 +76,8 @@ struct Cli {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    let mut config = config::Config::load(cli.config.as_ref())
-        .context("Failed to load configuration")?;
+    let mut config =
+        config::Config::load(cli.config.as_ref()).context("Failed to load configuration")?;
 
     // Apply CLI overrides to config
     if cli.mcp_config.is_some() {
@@ -91,7 +94,10 @@ async fn main() -> Result<()> {
 
     let theme_name = cli.theme.as_deref().unwrap_or(&config.theme);
     let theme = theme::Theme::load(theme_name).unwrap_or_else(|e| {
-        eprintln!("Warning: Failed to load theme '{}': {}. Using default.", theme_name, e);
+        eprintln!(
+            "Warning: Failed to load theme '{}': {}. Using default.",
+            theme_name, e
+        );
         theme::Theme::default_theme()
     });
 
@@ -111,7 +117,11 @@ async fn main() -> Result<()> {
 
     let (cols, rows) = crossterm::terminal::size().context("Failed to get terminal size")?;
     if cols < 40 || rows < 10 {
-        anyhow::bail!("Terminal too small ({}x{}). Need at least 40x10.", cols, rows);
+        anyhow::bail!(
+            "Terminal too small ({}x{}). Need at least 40x10.",
+            cols,
+            rows
+        );
     }
 
     // Initialize terminal
@@ -138,10 +148,7 @@ async fn main() -> Result<()> {
     );
     let result = app.run(&mut terminal).await;
 
-    let _ = crossterm::execute!(
-        std::io::stdout(),
-        crossterm::event::DisableBracketedPaste
-    );
+    let _ = crossterm::execute!(std::io::stdout(), crossterm::event::DisableBracketedPaste);
     ratatui::restore();
 
     result

--- a/src/pty/process.rs
+++ b/src/pty/process.rs
@@ -34,9 +34,7 @@ impl PtyProcess {
             .context("Failed to open PTY")?;
 
         let parts: Vec<&str> = command.split_whitespace().collect();
-        let (program, args) = parts
-            .split_first()
-            .context("Empty command")?;
+        let (program, args) = parts.split_first().context("Empty command")?;
 
         let mut cmd = CommandBuilder::new(program);
         cmd.args(args);
@@ -97,11 +95,7 @@ impl PtyProcess {
 
     #[allow(dead_code)]
     pub fn is_alive(&mut self) -> bool {
-        self.child
-            .try_wait()
-            .ok()
-            .flatten()
-            .is_none()
+        self.child.try_wait().ok().flatten().is_none()
     }
 
     pub fn kill(&mut self) {

--- a/src/terminal/converter.rs
+++ b/src/terminal/converter.rs
@@ -132,10 +132,7 @@ mod tests {
 
     #[test]
     fn test_convert_bg_colored_indexed_preserved() {
-        assert_eq!(
-            convert_bg(vt100::Color::Idx(1), TEST_BG),
-            Color::Indexed(1)
-        );
+        assert_eq!(convert_bg(vt100::Color::Idx(1), TEST_BG), Color::Indexed(1));
     }
 
     #[test]
@@ -145,10 +142,7 @@ mod tests {
 
     #[test]
     fn test_convert_fg_indexed() {
-        assert_eq!(
-            convert_fg(vt100::Color::Idx(1), TEST_BG),
-            Color::Indexed(1)
-        );
+        assert_eq!(convert_fg(vt100::Color::Idx(1), TEST_BG), Color::Indexed(1));
     }
 
     #[test]
@@ -218,9 +212,9 @@ mod tests {
 
     #[test]
     fn test_is_dark_bg() {
-        assert!(is_dark_bg(0, 0, 0));       // pure black
-        assert!(is_dark_bg(20, 20, 30));     // dark gray/blue
-        assert!(is_dark_bg(30, 30, 46));     // catppuccin base
+        assert!(is_dark_bg(0, 0, 0)); // pure black
+        assert!(is_dark_bg(20, 20, 30)); // dark gray/blue
+        assert!(is_dark_bg(30, 30, 46)); // catppuccin base
         assert!(!is_dark_bg(100, 100, 100)); // mid gray
         assert!(!is_dark_bg(255, 255, 255)); // white
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -286,7 +286,12 @@ mod tests {
             if path.extension().and_then(|e| e.to_str()) == Some("toml") {
                 let content = std::fs::read_to_string(&path).unwrap();
                 let result = Theme::from_toml(&content);
-                assert!(result.is_ok(), "Failed to parse theme {}: {:?}", path.display(), result.err());
+                assert!(
+                    result.is_ok(),
+                    "Failed to parse theme {}: {:?}",
+                    path.display(),
+                    result.err()
+                );
             }
         }
     }

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 
 /// A single todo item from Claude's TodoWrite tool.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct TodoItem {
     pub id: String,
     pub content: String,
@@ -63,6 +64,7 @@ impl TodoTracker {
     }
 
     /// Count of pending + in_progress items.
+    #[allow(dead_code)]
     pub fn active_count(&self) -> usize {
         self.items
             .iter()
@@ -89,6 +91,7 @@ impl TodoTracker {
     }
 
     /// Returns the currently in-progress task content, if any.
+    #[allow(dead_code)]
     pub fn current_task(&self) -> Option<&str> {
         self.items
             .iter()
@@ -144,7 +147,8 @@ mod tests {
     #[test]
     fn test_replaces_previous_list() {
         let mut tracker = TodoTracker::new();
-        tracker.apply_todo_write(r#"{"todos": [{"id": "1", "content": "Old", "status": "pending"}]}"#);
+        tracker
+            .apply_todo_write(r#"{"todos": [{"id": "1", "content": "Old", "status": "pending"}]}"#);
         assert_eq!(tracker.items.len(), 1);
 
         tracker.apply_todo_write(r#"{"todos": [{"id": "2", "content": "New A", "status": "pending"}, {"id": "3", "content": "New B", "status": "pending"}]}"#);

--- a/src/ui/borders.rs
+++ b/src/ui/borders.rs
@@ -11,11 +11,7 @@ pub fn themed_block<'a>(title: &'a str, focused: bool, theme: &Theme) -> Block<'
         theme.border
     };
 
-    let title_style = Style::default().fg(if focused {
-        theme.primary
-    } else {
-        theme.border
-    });
+    let title_style = Style::default().fg(if focused { theme.primary } else { theme.border });
 
     Block::default()
         .title(title)

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -35,7 +35,11 @@ pub struct Header<'a> {
 
 impl<'a> Header<'a> {
     pub fn new(theme: &'a Theme, frame_count: u64) -> Self {
-        Self { theme, frame_count, compact: false }
+        Self {
+            theme,
+            frame_count,
+            compact: false,
+        }
     }
 
     pub fn compact(mut self, compact: bool) -> Self {
@@ -71,10 +75,15 @@ impl Widget for Header<'_> {
             let phase = frame as f64 * 0.02;
             for (i, ch) in text.chars().enumerate() {
                 let x = start_x + i as u16;
-                if x >= area.right() { break; }
+                if x >= area.right() {
+                    break;
+                }
                 let position = (i as f64 / text_len.max(1) as f64) + phase;
                 let color = gradient_color(self.theme, position);
-                let style = Style::default().fg(color).bg(bg).add_modifier(Modifier::BOLD);
+                let style = Style::default()
+                    .fg(color)
+                    .bg(bg)
+                    .add_modifier(Modifier::BOLD);
                 if let Some(cell) = buf.cell_mut((x, y)) {
                     cell.set_char(ch);
                     cell.set_style(style);
@@ -217,7 +226,8 @@ impl Header<'_> {
 
 /// Simple pseudo-random hash for deterministic sparkle placement.
 fn pseudo_hash(x: u64, y: u64, frame: u64) -> u64 {
-    let mut v = x.wrapping_mul(2654435761) ^ y.wrapping_mul(2246822519) ^ frame.wrapping_mul(3266489917);
+    let mut v =
+        x.wrapping_mul(2654435761) ^ y.wrapping_mul(2246822519) ^ frame.wrapping_mul(3266489917);
     v ^= v >> 16;
     v = v.wrapping_mul(0x45d9f3b);
     v ^= v >> 16;

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -79,10 +79,7 @@ struct RenderContext<'a> {
 
 impl<'a> RenderContext<'a> {
     fn current_style(&self) -> Style {
-        self.style_stack
-            .last()
-            .copied()
-            .unwrap_or(self.base_style)
+        self.style_stack.last().copied().unwrap_or(self.base_style)
     }
 
     fn push_modifier(&mut self, modifier: Modifier) {
@@ -152,7 +149,8 @@ impl<'a> RenderContext<'a> {
                 let fence_style = Style::default()
                     .fg(Color::Rgb(127, 132, 156))
                     .add_modifier(Modifier::DIM);
-                self.lines.push(StyledLine::plain(&fence_label, fence_style));
+                self.lines
+                    .push(StyledLine::plain(&fence_label, fence_style));
             }
 
             Event::End(TagEnd::CodeBlock) => {
@@ -360,9 +358,7 @@ impl<'a> RenderContext<'a> {
             Some(syn) => {
                 let mut h = HighlightLines::new(syn, self.syntax_theme);
                 for line in self.code_block_buf.lines() {
-                    let ranges = h
-                        .highlight_line(line, self.ss)
-                        .unwrap_or_default();
+                    let ranges = h.highlight_line(line, self.ss).unwrap_or_default();
                     let spans: Vec<StyledSpan> = ranges
                         .iter()
                         .map(|(style, text)| {
@@ -459,7 +455,13 @@ mod tests {
         // First and last lines should be fences
         let first_text: String = lines[0].spans.iter().map(|s| s.text.as_str()).collect();
         assert!(first_text.contains("```rust"));
-        let last_text: String = lines.last().unwrap().spans.iter().map(|s| s.text.as_str()).collect();
+        let last_text: String = lines
+            .last()
+            .unwrap()
+            .spans
+            .iter()
+            .map(|s| s.text.as_str())
+            .collect();
         assert!(last_text.contains("```"));
     }
 

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -62,7 +62,9 @@ impl OverlayState {
 
     pub fn selected_value(&self) -> Option<String> {
         let filtered = self.filtered_items();
-        filtered.get(self.selected).map(|(_, item)| item.value.clone())
+        filtered
+            .get(self.selected)
+            .map(|(_, item)| item.value.clone())
     }
 
     pub fn type_char(&mut self, c: char) {
@@ -85,7 +87,11 @@ pub struct OverlayWidget<'a> {
 
 impl<'a> OverlayWidget<'a> {
     pub fn new(title: &'a str, state: &'a OverlayState, theme: &'a Theme) -> Self {
-        Self { title, state, theme }
+        Self {
+            title,
+            state,
+            theme,
+        }
     }
 
     /// Calculate the centered popup area.
@@ -116,11 +122,19 @@ impl Widget for OverlayWidget<'_> {
         // Draw border
         let block = Block::default()
             .title(format!(" {} ", self.title))
-            .title_style(Style::default().fg(self.theme.primary).add_modifier(Modifier::BOLD))
+            .title_style(
+                Style::default()
+                    .fg(self.theme.primary)
+                    .add_modifier(Modifier::BOLD),
+            )
             .borders(Borders::ALL)
             .border_set(border::ROUNDED)
             .border_style(Style::default().fg(self.theme.border_focused))
-            .style(Style::default().bg(self.theme.surface).fg(self.theme.foreground));
+            .style(
+                Style::default()
+                    .bg(self.theme.surface)
+                    .fg(self.theme.foreground),
+            );
 
         let inner = block.inner(popup);
         block.render(popup, buf);
@@ -133,7 +147,9 @@ impl Widget for OverlayWidget<'_> {
         let filter_y = inner.y;
         let prompt = "> ";
         let filter_text = format!("{}{}", prompt, self.state.filter);
-        let filter_style = Style::default().fg(self.theme.accent).bg(self.theme.surface);
+        let filter_style = Style::default()
+            .fg(self.theme.accent)
+            .bg(self.theme.surface);
         for (i, ch) in filter_text.chars().enumerate() {
             let x = inner.x + i as u16;
             if x >= inner.right() {
@@ -149,7 +165,11 @@ impl Widget for OverlayWidget<'_> {
         if cursor_x < inner.right() {
             if let Some(cell) = buf.cell_mut((cursor_x, filter_y)) {
                 cell.set_char('_');
-                cell.set_style(Style::default().fg(self.theme.input_cursor).bg(self.theme.surface));
+                cell.set_style(
+                    Style::default()
+                        .fg(self.theme.input_cursor)
+                        .bg(self.theme.surface),
+                );
             }
         }
         // Fill rest of filter row
@@ -166,7 +186,11 @@ impl Widget for OverlayWidget<'_> {
             for x in inner.x..inner.right() {
                 if let Some(cell) = buf.cell_mut((x, sep_y)) {
                     cell.set_char('─');
-                    cell.set_style(Style::default().fg(self.theme.border).bg(self.theme.surface));
+                    cell.set_style(
+                        Style::default()
+                            .fg(self.theme.border)
+                            .bg(self.theme.surface),
+                    );
                 }
             }
         }
@@ -200,7 +224,9 @@ impl Widget for OverlayWidget<'_> {
                     .bg(self.theme.overlay)
                     .add_modifier(Modifier::BOLD)
             } else {
-                Style::default().fg(self.theme.foreground).bg(self.theme.surface)
+                Style::default()
+                    .fg(self.theme.foreground)
+                    .bg(self.theme.surface)
             };
 
             // Fill row background
@@ -227,9 +253,13 @@ impl Widget for OverlayWidget<'_> {
             // Write hint on the right side
             if !hint.is_empty() {
                 let hint_style = if is_selected {
-                    Style::default().fg(self.theme.secondary).bg(self.theme.overlay)
+                    Style::default()
+                        .fg(self.theme.secondary)
+                        .bg(self.theme.overlay)
                 } else {
-                    Style::default().fg(self.theme.border).bg(self.theme.surface)
+                    Style::default()
+                        .fg(self.theme.border)
+                        .bg(self.theme.surface)
                 };
                 let hint_start = inner.right().saturating_sub(hint.len() as u16 + 1);
                 for (i, ch) in hint.chars().enumerate() {
@@ -295,10 +325,8 @@ mod tests {
 
     #[test]
     fn test_overlay_state_selected_value() {
-        let mut state = OverlayState::new(
-            vec![item("A", "val-a", ""), item("B", "val-b", "")],
-            None,
-        );
+        let mut state =
+            OverlayState::new(vec![item("A", "val-a", ""), item("B", "val-b", "")], None);
         assert_eq!(state.selected_value(), Some("val-a".to_string()));
         state.move_down();
         assert_eq!(state.selected_value(), Some("val-b".to_string()));

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -23,6 +23,7 @@ pub struct StatusBar<'a> {
 }
 
 impl<'a> StatusBar<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         theme: &'a Theme,
         input_tokens: u64,
@@ -69,7 +70,14 @@ fn context_bar(total_tokens: u64, bar_width: usize) -> (String, f64) {
 
 /// Write a string into the buffer at (start_x, y) with the given style.
 /// Returns the x position after the last written character.
-fn write_str(buf: &mut Buffer, text: &str, x_start: u16, y: u16, x_limit: u16, style: Style) -> u16 {
+fn write_str(
+    buf: &mut Buffer,
+    text: &str,
+    x_start: u16,
+    y: u16,
+    x_limit: u16,
+    style: Style,
+) -> u16 {
     let mut x = x_start;
     for ch in text.chars() {
         if x >= x_limit {
@@ -114,9 +122,7 @@ impl<'a> Widget for StatusBar<'a> {
             };
             let sep = " | ";
             left_end = write_str(buf, sep, left_end, area.y, area.right(), style);
-            let mode_style = Style::default()
-                .fg(color)
-                .bg(self.theme.status_bg);
+            let mode_style = Style::default().fg(color).bg(self.theme.status_bg);
             left_end = write_str(buf, label, left_end, area.y, area.right(), mode_style);
         }
 
@@ -130,9 +136,7 @@ impl<'a> Widget for StatusBar<'a> {
             } else {
                 self.theme.success
             };
-            let git_style = Style::default()
-                .fg(git_color)
-                .bg(self.theme.status_bg);
+            let git_style = Style::default().fg(git_color).bg(self.theme.status_bg);
             left_end = write_str(buf, &display, left_end, area.y, area.right(), git_style);
         }
 
@@ -161,13 +165,15 @@ impl<'a> Widget for StatusBar<'a> {
         let total_tokens = self.input_tokens + self.output_tokens;
         let has_usage = total_tokens > 0;
 
-        let short_model = self.model_name
-            .map(|m| cost::short_model_name(m))
+        let short_model = self
+            .model_name
+            .map(cost::short_model_name)
             .unwrap_or_default();
 
         let center_text = if has_usage {
-            let pricing = self.model_name
-                .map(|m| cost::pricing_for_model(m))
+            let pricing = self
+                .model_name
+                .map(cost::pricing_for_model)
                 .unwrap_or_else(|| cost::pricing_for_model("sonnet"));
             let session_cost = pricing.calculate_cost(self.input_tokens, self.output_tokens);
             let pct = ((total_tokens as f64 / CONTEXT_WINDOW_TOKENS as f64) * 100.0).min(100.0);
@@ -203,9 +209,7 @@ impl<'a> Widget for StatusBar<'a> {
             } else {
                 self.theme.error
             };
-            let bar_style = Style::default()
-                .fg(bar_color)
-                .bg(self.theme.status_bg);
+            let bar_style = Style::default().fg(bar_color).bg(self.theme.status_bg);
             write_str(buf, &bar, after_text, area.y, area.right(), bar_style);
         }
 

--- a/tests/pty_integration_test.rs
+++ b/tests/pty_integration_test.rs
@@ -16,7 +16,10 @@ fn test_pty_spawn_echo() {
         .expect("Failed to open PTY");
 
     // Clone reader BEFORE spawning so we have it ready
-    let mut reader = pair.master.try_clone_reader().expect("Failed to clone reader");
+    let mut reader = pair
+        .master
+        .try_clone_reader()
+        .expect("Failed to clone reader");
 
     let mut cmd = CommandBuilder::new("echo");
     cmd.arg("hello from pty");
@@ -65,7 +68,10 @@ fn test_pty_vt100_captures_output() {
         .expect("Failed to open PTY");
 
     // Clone reader BEFORE spawning
-    let mut reader = pair.master.try_clone_reader().expect("Failed to clone reader");
+    let mut reader = pair
+        .master
+        .try_clone_reader()
+        .expect("Failed to clone reader");
 
     let mut cmd = CommandBuilder::new("printf");
     cmd.arg("Line1\\nLine2\\nLine3");


### PR DESCRIPTION
## Summary

- **Fix /resume and /rewind bugs** (#47, #49) — routed through `LocalAction` to open session picker / checkpoint timeline instead of sending raw commands to CLI
- **Redesign plugin modal** (#48) — smaller centered dialog (60%/50%), async install/uninstall with loading indicator via `tokio::task::spawn_blocking`
- **Add CI pipeline** — GitHub Actions with `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` on ubuntu + macOS; release workflow for automated binary builds on tag push
- **Dead code cleanup** — removed unused `spawn()`/`spawn_with_resume()` wrappers and `push_system_message()`
- **Fix all 16 clippy warnings** for zero-warning builds

Closes #47, closes #48, closes #49

## Test plan

- [ ] Verify `/resume` opens session picker when typed in input
- [ ] Verify `/rewind` opens checkpoint timeline when typed in input
- [ ] Verify plugin modal is smaller and shows loading indicator during install/uninstall
- [ ] Verify `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` all pass
- [ ] Verify CI runs on push to master / PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)